### PR TITLE
Don't decrypt and extract secrets in PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ before_install:
   - mkdir "$ANDROID_HOME/licenses" || true
   - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
   - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-  - openssl aes-256-cbc -K $encrypted_1f32612fea61_key -iv $encrypted_1f32612fea61_iv -in secrets.tar.enc -out secrets.tar -d
-  - tar xvf secrets.tar
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -K $encrypted_1f32612fea61_key -iv $encrypted_1f32612fea61_iv -in secrets.tar.enc -out secrets.tar -d; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then tar xvf secrets.tar; fi'
 
 script: ./scripts/play-publish-if-not-pr.sh
 


### PR DESCRIPTION
Travis should not try to decrypt and extract secrets in Pull Requests as environment variables are not available then, to prevent false build failures.